### PR TITLE
Added defaultScope functionality

### DIFF
--- a/src/uncompressed/TimelineLite.js
+++ b/src/uncompressed/TimelineLite.js
@@ -50,7 +50,7 @@
 			_pauseCallback = function(tween, callback, params, scope) {
 				tween._timeline.pause(tween._startTime);
 				if (callback) {
-					callback.apply(scope || tween._timeline, params || _blankArray);
+					callback.apply(scope || this.vars.defaultScope || tween._timeline, params || _blankArray);
 				}
 			},
 			_slice = _blankArray.slice,
@@ -106,7 +106,7 @@
 		};
 		
 		p.call = function(callback, params, scope, position) {
-			return this.add( TweenLite.delayedCall(0, callback, params, scope), position);
+			return this.add( TweenLite.delayedCall(0, callback, params, scope || this.vars.defaultScope), position);
 		};
 		
 		p.set = function(target, vars, position) {
@@ -243,7 +243,7 @@
 		};
 
 		p.addPause = function(position, callback, params, scope) {
-			return this.call(_pauseCallback, ["{self}", callback, params, scope], this, position);
+			return this.call(_pauseCallback, ["{self}", callback, params, scope || this.vars.defaultScope], this, position);
 		};
 	
 		p.removeLabel = function(label) {
@@ -364,7 +364,7 @@
 			}
 
 			if (prevTime === 0) if (this.vars.onStart) if (this._time !== 0) if (!suppressEvents) {
-				this.vars.onStart.apply(this.vars.onStartScope || this, this.vars.onStartParams || _blankArray);
+				this.vars.onStart.apply(this.vars.onStartScope || this.vars.defaultScope || this, this.vars.onStartParams || _blankArray);
 			}
 
 			if (this._time >= prevTime) {
@@ -400,7 +400,7 @@
 			}
 			
 			if (this._onUpdate) if (!suppressEvents) {
-				this._onUpdate.apply(this.vars.onUpdateScope || this, this.vars.onUpdateParams || _blankArray);
+				this._onUpdate.apply(this.vars.onUpdateScope || this.vars.defaultScope ||this, this.vars.onUpdateParams || _blankArray);
 			}
 			
 			if (callback) if (!this._gc) if (prevStart === this._startTime || prevTimeScale !== this._timeScale) if (this._time === 0 || totalDur >= this.totalDuration()) { //if one of the tweens that was rendered altered this timeline's startTime (like if an onComplete reversed the timeline), it probably isn't complete. If it is, don't worry, because whatever call altered the startTime would complete if it was necessary at the new time. The only exception is the timeScale property. Also check _gc because there's a chance that kill() could be called in an onUpdate
@@ -411,7 +411,7 @@
 					this._active = false;
 				}
 				if (!suppressEvents && this.vars[callback]) {
-					this.vars[callback].apply(this.vars[callback + "Scope"] || this, this.vars[callback + "Params"] || _blankArray);
+					this.vars[callback].apply(this.vars[callback + "Scope"] || this.vars.defaultScope || this, this.vars[callback + "Params"] || _blankArray);
 				}
 			}
 		};

--- a/src/uncompressed/TimelineMax.js
+++ b/src/uncompressed/TimelineMax.js
@@ -42,7 +42,7 @@
 		};
 		
 		p.addCallback = function(callback, position, params, scope) {
-			return this.add( TweenLite.delayedCall(0, callback, params, scope), position);
+			return this.add( TweenLite.delayedCall(0, callback, params, scope || this.vars.defaultScope), position);
 		};
 		
 		p.removeCallback = function(callback, position) {
@@ -79,7 +79,7 @@
 					t.duration( Math.abs( t.vars.time - t.target.time()) / t.target._timeScale );
 				}
 				if (vars.onStart) { //in case the user had an onStart in the vars - we don't want to overwrite it.
-					vars.onStart.apply(vars.onStartScope || t, vars.onStartParams || _blankArray);
+					vars.onStart.apply(vars.onStartScope || this.vars.defaultScope || t, vars.onStartParams || _blankArray);
 				}
 			};
 			return t;
@@ -214,7 +214,7 @@
 				this.render(prevTime, suppressEvents, (dur === 0));
 				if (!suppressEvents) if (!this._gc) {
 					if (this.vars.onRepeat) {
-						this.vars.onRepeat.apply(this.vars.onRepeatScope || this, this.vars.onRepeatParams || _blankArray);
+						this.vars.onRepeat.apply(this.vars.onRepeatScope || this.vars.defaultScope || this, this.vars.onRepeatParams || _blankArray);
 					}
 				}
 				if (wrap) {
@@ -233,7 +233,7 @@
 
 			if ((this._time === prevTime || !this._first) && !force && !internalForce) {
 				if (prevTotalTime !== this._totalTime) if (this._onUpdate) if (!suppressEvents) { //so that onUpdate fires even during the repeatDelay - as long as the totalTime changed, we should trigger onUpdate.
-					this._onUpdate.apply(this.vars.onUpdateScope || this, this.vars.onUpdateParams || _blankArray);
+					this._onUpdate.apply(this.vars.onUpdateScope || this.vars.defaultScope || this, this.vars.onUpdateParams || _blankArray);
 				}
 				return;
 			} else if (!this._initted) {
@@ -245,7 +245,7 @@
 			}
 			
 			if (prevTotalTime === 0) if (this.vars.onStart) if (this._totalTime !== 0) if (!suppressEvents) {
-				this.vars.onStart.apply(this.vars.onStartScope || this, this.vars.onStartParams || _blankArray);
+				this.vars.onStart.apply(this.vars.onStartScope || this.vars.defaultScope || this, this.vars.onStartParams || _blankArray);
 			}
 
 			if (this._time >= prevTime) {
@@ -282,7 +282,7 @@
 			}
 			
 			if (this._onUpdate) if (!suppressEvents) {
-				this._onUpdate.apply(this.vars.onUpdateScope || this, this.vars.onUpdateParams || _blankArray);
+				this._onUpdate.apply(this.vars.onUpdateScope || this.vars.defaultScope || this, this.vars.onUpdateParams || _blankArray);
 			}
 			if (callback) if (!this._locked) if (!this._gc) if (prevStart === this._startTime || prevTimeScale !== this._timeScale) if (this._time === 0 || totalDur >= this.totalDuration()) { //if one of the tweens that was rendered altered this timeline's startTime (like if an onComplete reversed the timeline), it probably isn't complete. If it is, don't worry, because whatever call altered the startTime would complete if it was necessary at the new time. The only exception is the timeScale property. Also check _gc because there's a chance that kill() could be called in an onUpdate
 				if (isComplete) {
@@ -292,7 +292,7 @@
 					this._active = false;
 				}
 				if (!suppressEvents && this.vars[callback]) {
-					this.vars[callback].apply(this.vars[callback + "Scope"] || this, this.vars[callback + "Params"] || _blankArray);
+					this.vars[callback].apply(this.vars[callback + "Scope"] || this.vars.defaultScope || this, this.vars[callback + "Params"] || _blankArray);
 				}
 			}
 		};
@@ -488,7 +488,7 @@
 			_pauseCallback = function(tween, callback, params, scope) {
 				tween._timeline.pause(tween._startTime);
 				if (callback) {
-					callback.apply(scope || tween._timeline, params || _blankArray);
+					callback.apply(scope || this.vars.defaultScope || tween._timeline, params || _blankArray);
 				}
 			},
 			_slice = _blankArray.slice,
@@ -544,7 +544,7 @@
 		};
 
 		p.call = function(callback, params, scope, position) {
-			return this.add( TweenLite.delayedCall(0, callback, params, scope), position);
+			return this.add( TweenLite.delayedCall(0, callback, params, scope || this.vars.defaultScope), position);
 		};
 
 		p.set = function(target, vars, position) {
@@ -681,7 +681,7 @@
 		};
 
 		p.addPause = function(position, callback, params, scope) {
-			return this.call(_pauseCallback, ["{self}", callback, params, scope], this, position);
+			return this.call(_pauseCallback, ["{self}", callback, params, scope || this.vars.defaultScope], this, position);
 		};
 
 		p.removeLabel = function(label) {
@@ -802,7 +802,7 @@
 			}
 
 			if (prevTime === 0) if (this.vars.onStart) if (this._time !== 0) if (!suppressEvents) {
-				this.vars.onStart.apply(this.vars.onStartScope || this, this.vars.onStartParams || _blankArray);
+				this.vars.onStart.apply(this.vars.onStartScope || this.vars.defaultScope || this, this.vars.onStartParams || _blankArray);
 			}
 
 			if (this._time >= prevTime) {
@@ -838,7 +838,7 @@
 			}
 
 			if (this._onUpdate) if (!suppressEvents) {
-				this._onUpdate.apply(this.vars.onUpdateScope || this, this.vars.onUpdateParams || _blankArray);
+				this._onUpdate.apply(this.vars.onUpdateScope || this.vars.defaultScope || this, this.vars.onUpdateParams || _blankArray);
 			}
 
 			if (callback) if (!this._gc) if (prevStart === this._startTime || prevTimeScale !== this._timeScale) if (this._time === 0 || totalDur >= this.totalDuration()) { //if one of the tweens that was rendered altered this timeline's startTime (like if an onComplete reversed the timeline), it probably isn't complete. If it is, don't worry, because whatever call altered the startTime would complete if it was necessary at the new time. The only exception is the timeScale property. Also check _gc because there's a chance that kill() could be called in an onUpdate
@@ -849,7 +849,7 @@
 					this._active = false;
 				}
 				if (!suppressEvents && this.vars[callback]) {
-					this.vars[callback].apply(this.vars[callback + "Scope"] || this, this.vars[callback + "Params"] || _blankArray);
+					this.vars[callback].apply(this.vars[callback + "Scope"] || this.vars.defaultScope || this, this.vars[callback + "Params"] || _blankArray);
 				}
 			}
 		};

--- a/src/uncompressed/TweenLite.js
+++ b/src/uncompressed/TweenLite.js
@@ -1325,7 +1325,7 @@
 					}
 				}
 				if (this.vars.onStart) if (this._time !== 0 || duration === 0) if (!suppressEvents) {
-					this.vars.onStart.apply(this.vars.onStartScope || this, this.vars.onStartParams || _blankArray);
+					this.vars.onStart.apply(this.vars.onStartScope || this.vars.defaultScope || this, this.vars.onStartParams || _blankArray);
 				}
 			}
 
@@ -1344,7 +1344,7 @@
 					this._startAt.render(time, suppressEvents, force); //note: for performance reasons, we tuck this conditional logic inside less traveled areas (most tweens don't have an onUpdate). We'd just have it at the end before the onComplete, but the values should be updated before any onUpdate is called, so we ALSO put it here and then if it's not called, we do so later near the onComplete.
 				}
 				if (!suppressEvents) if (this._time !== prevTime || isComplete) {
-					this._onUpdate.apply(this.vars.onUpdateScope || this, this.vars.onUpdateParams || _blankArray);
+					this._onUpdate.apply(this.vars.onUpdateScope || this.vars.defaultScope || this, this.vars.onUpdateParams || _blankArray);
 				}
 			}
 
@@ -1359,7 +1359,7 @@
 					this._active = false;
 				}
 				if (!suppressEvents && this.vars[callback]) {
-					this.vars[callback].apply(this.vars[callback + "Scope"] || this, this.vars[callback + "Params"] || _blankArray);
+					this.vars[callback].apply(this.vars[callback + "Scope"] || this.vars.defaultScope || this, this.vars[callback + "Params"] || _blankArray);
 				}
 				if (duration === 0 && this._rawPrevTime === _tinyNum && rawPrevTime !== _tinyNum) { //the onComplete or onReverseComplete could trigger movement of the playhead and for zero-duration tweens (which must discern direction) that land directly back on their start time, we don't want to fire again on the next render. Think of several addPause()'s in a timeline that forces the playhead to a certain spot, but what if it's already paused and another tween is tweening the "time" of the timeline? Each time it moves [forward] past that spot, it would move back, and since suppressEvents is true, it'd reset _rawPrevTime to _tinyNum so that when it begins again, the callback would fire (so ultimately it could bounce back and forth during that tween). Again, this is a very uncommon scenario, but possible nonetheless.
 					this._rawPrevTime = 0;

--- a/src/uncompressed/utils/Draggable.js
+++ b/src/uncompressed/utils/Draggable.js
@@ -205,7 +205,7 @@
 					callback = vars[callbackName],
 					listeners = instance._listeners[type];
 				if (typeof(callback) === "function") {
-					callback.apply(vars[callbackName + "Scope"] || instance, vars[callbackName + "Params"] || [instance.pointerEvent]);
+					callback.apply(vars[callbackName + "Scope"] || this.vars.defaultScope || instance, vars[callbackName + "Params"] || [instance.pointerEvent]);
 				}
 				if (listeners) {
 					instance.dispatchEvent(type);
@@ -884,7 +884,7 @@
 							}
 						}
 						if (vars.onThrowUpdate && !skipOnUpdate) {
-							vars.onThrowUpdate.apply(vars.onThrowUpdateScope || self, vars.onThrowUpdateParams || _emptyArray);
+							vars.onThrowUpdate.apply(vars.onThrowUpdateScope || this.vars.defaultScope || self, vars.onThrowUpdateParams || _emptyArray);
 						}
 					},
 


### PR DESCRIPTION
Added defaultScope functionality, as per this forum post:

http://forums.greensock.com/topic/9938-default-scope-for-events-and-callbacks/

Demo code:

``` javascript
function Scene()
{
    // callbacks
        var props = 
        {
            defaultScope        :this, 
            onStart             :this.onStart,
            onUpdate            :this.onUpdate,
            onRepeat            :this.onRepeat,
            onComplete          :this.onComplete,
            onReverseComplete   :this.onReverseComplete
        }

    // animation
        this.tl = new TimelineMax(props);
        this.tl
            .to(this, 0.2, {value:1})
            .call(this.callback)
            .addPause(0.2, this.onPause);

    // resume after pause by moving mouse
        $('body')
            .one('mousemove', $.proxy(this.resume, this) );
}

Scene.prototype  =
{
    // properties
        tl      :null,
        value   :0,

    // events
        onStart:function()
        {
            console.log('start: ', this);
        },

        onPause:function()
        {
            console.log('pause: ', this);
            console.log('move mouse to resume animation...');
        },

        onComplete:function()
        {
            console.log('complete: ', this);
        },

        onRepeat:function()
        {
            console.log('repeat: ', this);
        },

        onReverseComplete:function()
        {
            console.log('reverse complete: ', this);
        },

        onUpdate:function()
        {
            console.log('update: ', this.value);
        },

    // callbacks
        resume:function()
        {
             this.tl
                .reverse()
                .repeat(1); // add a repeat
        },

        callback:function()
        {
            console.log('callback: ', this);
        }

}

console.clear();
new Scene();
```

Output:

```
Scene

start:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 0, onStart: function, onPause: function…}

update:  0
update:  0.6459750000007792
update:  0.8479000000011634
update:  0.9743999999994645
callback:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 1, onStart: function, onPause: function…}

pause:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 1, onStart: function, onPause: function…}

move mouse to resume animation...
update:  1
repeat:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 1, onStart: function, onPause: function…}

update:  0.9600000000000728
update:  0.8400000000002911
update:  0.5904000000019092
update:  0.36000000000116417
update:  0
update:  0
repeat:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 0, onStart: function, onPause: function…}

update:  0.9600000000004366
update:  0.8400000000010187
update:  0.6339750000005284
update:  0.36000000000261956
update:  0
reverse complete:  Scene {tl: TimelineMax, _gsTweenID: "t31", value: 0, onStart: function, onPause: function…}

```
