### PR TITLE
use "repository" instead of "repositories"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,8 @@
    "bugs": {
     "url": "http://greensock.com/forums/"
   },
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/greensock/GreenSock-JS" 
-       } 
-   ]
-
+   "repository": {
+    "type": "git",
+    "url": "https://github.com/greensock/GreenSock-JS" 
+   } 
 }


### PR DESCRIPTION
repositories isn't actually a thing that's supported.