### PR TITLE
Snap SVG Plugin

### DIFF
--- a/src/uncompressed/plugins/SnapPlugin.js
+++ b/src/uncompressed/plugins/SnapPlugin.js
@@ -97,6 +97,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 			if (rec) {
 				t._gsTransform = m; //record to the object's _gsTransform which we use so that tweens can control individual properties independently (we need all the properties to accurately recompose the matrix in the setRatio() method)
 			}
+			
 			return m;
 		},
 
@@ -204,9 +205,6 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 						_arr2 = Snap.parsePathString(v);
 						pt.t[pt.p] = s; //add property to target
 						
-						console.log(_arr1);
-						console.log(_arr2);
-						
 						for (i = 0; i < _arr1.length; i += 1) {
 							for (j = 0; j < _arr1[i].length; j += 1) {
 								
@@ -305,6 +303,13 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 
 				//apply transform values like x, y, scaleX, scaleY, rotation, skewX, or skewY. We do these after looping through all the PropTweens because those are where the changes are made to scaleX/scaleY/rotation/skewX/skewY/x/y.
 				if (this._transform) {
+					
+					//these fix transform string
+					this._pxg = this._pxg ? this._pxg : 0;
+					this._pyg = this._pyg ? this._pyg : 0;
+					this._pxl = this._pxl ? this._pxl : 0;
+					this._pyl = this._pyl ? this._pyl : 0;
+					
 					pt = this._transform; //to improve speed and reduce size, reuse the pt variable as an alias to the _transform property
 					var ang = pt.rotation,
 						skew = ang - pt.skewX,
@@ -323,8 +328,10 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 					if (c < min) if (c > -min) {
 						c = 0;
 					}
+					
 					pt.ox = this._pxg - (pxl * a + pyl * c); //we must record the offset x/y that we're making from the regular tx/ty (matrix.e and f) so that we can correctly interpret positional data in _getTransform(). See note there on tx and ox.
 					pt.oy = this._pyg - (pxl * b + pyl * d);
+					
 					this._target.transform("m" + a + "," + b + "," + c + "," + d + "," + (pt.tx + pt.ox) + "," + (pt.ty + pt.oy));
 				}
 
@@ -413,7 +420,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 				this._pyg = dy - m1.ty;
 			}
 
-		} else if (typeof(v) === "string") { //for values like transform:"rotate(60deg) scale(0.5, 0.8)"
+		} else if (typeof(v) === "string") { //for values like transform:"rotate(60deg) scale(0.5, 0.8)"			
 			copy = this._target.transform();
 			t.transform(v);
 			m2 = _getTransform(t, false);


### PR DESCRIPTION
This is a plug-in to support Snap SVG (http://snapsvg.io/). Based off of the original Raphael plug-in due to their similar API. However, this includes edits to support changes in how the transform matrix is referenced as well as animating new features supported by Snap such as polygon and path shape tweening.

Below is an example of how properties are animated with the plug-in:

```
var s = new Snap(1024, 768);            
var rect = s.rect(50, 30, 200, 100);
rect.attr('fill', '#f00');

var poly = s.polygon("21.8,38 61,73.4 31.8,100.7 77.7,115 116.2,139.2 139.9,76.5 169.7,47.3 73.4,25.6 102.6,56");
poly.attr('fill', 'red');

var path = s.path("M70.3,103.2c0,0-7.5-58.4,42.9-48.4s43.5,74.5,72,37.9s49.7-72,67.1-36s83.9,92.5,14.3,96.3c-69.6,3.7-82,18-88.8,44.1c-6.8,26.1-93.8,29.8-91.3-18S75.3,134.9,70.3,103.2z");
path.attr({
   'fill': 'orange',
   'transform': "translate(300, 200)"
});

var circle = s.circle(100, 100, 50);
circle.attr({fill: 'green'})

var tl = new TimelineMax();
tl.add(TweenMax.to(rect, 1, {snap:{fill:"#00f", width:100, height:50, x: 100, y: 100}, ease:Power1.easeInOut}));
tl.add(TweenMax.to(rect, 1, {snap:{opacity: 0}, ease:Sine.easeInOut, yoyo: true, repeat: 1}));
tl.add(TweenMax.to(circle, 1, {snap:{cx: 200, cy: 400, r: 100, opacity: 0.5}, ease:Power1.easeInOut}));
tl.add(TweenMax.to(poly, 1, {snap:{points: "68.4,69.7 11.9,83.3 62.2,102.6 69,148.6 111.3,113.8 178.4,139.5 111.9,47.9 103.2,62.9 42.3,36.8"}, ease:Quad.easeOut}));
tl.add(TweenMax.to(path, 1, {snap:{tx: 0, ty: 0, scaleX: 1.5, scaleY: 1.5}, ease:Quad.easeOut}));
tl.add(TweenMax.to(path, 1, {snap:{d: "M39.9,110.7c0,0,18.6-42.2,68.9-32.3s38.5,11.9,67.1-24.7s44.7,9.8,62.1,45.9s39.1,77-30.4,80.7c-69.6,3.7,19.9,26.1,13,52.2c-6.8,26.1-110.6-11.8-108.1-59.6C115,125,44.8,142.4,39.9,110.7z"}, ease:Quad.easeOut}));     
```
