### PR TITLE
Fix for CSSPlugin.cascadeTo

### DIFF
--- a/src/uncompressed/TweenMax.js
+++ b/src/uncompressed/TweenMax.js
@@ -4692,9 +4692,9 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 				i, difs, p;
 			target = tween._targets || tween.target;
 			_getChildStyles(target, b, targets);
-			tween.render(duration, true);
+			tween.render(duration, true, true);
 			_getChildStyles(target, e);
-			tween.render(0, true);
+			tween.render(0, true, true);
 			tween._enabled(true);
 			i = targets.length;
 			while (--i > -1) {

--- a/src/uncompressed/TweenMax.js
+++ b/src/uncompressed/TweenMax.js
@@ -4706,7 +4706,11 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 							difs[p] = vars[p];
 						}
 					}
-					results.push( TweenLite.to(targets[i], duration, difs) );
+					var from = {};
+					for (var prop in difs) {
+					    from[prop] = b[i][prop];
+					}
+					results.push(TweenLite.fromTo(targets[i], duration, from, difs));
 				}
 			}
 			return results;

--- a/src/uncompressed/plugins/CSSPlugin.js
+++ b/src/uncompressed/plugins/CSSPlugin.js
@@ -2386,7 +2386,11 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 							difs[p] = vars[p];
 						}
 					}
-					results.push( TweenLite.to(targets[i], duration, difs) );
+					var from = {};
+					for (var prop in difs) {
+					    from[prop] = b[i][prop];
+					}
+					results.push(TweenLite.fromTo(targets[i], duration, from, difs));
 				}
 			}
 			return results;

--- a/src/uncompressed/plugins/CSSPlugin.js
+++ b/src/uncompressed/plugins/CSSPlugin.js
@@ -2372,9 +2372,9 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 				i, difs, p;
 			target = tween._targets || tween.target;
 			_getChildStyles(target, b, targets);
-			tween.render(duration, true);
+			tween.render(duration, true, true);
 			_getChildStyles(target, e);
-			tween.render(0, true);
+			tween.render(0, true, true);
 			tween._enabled(true);
 			i = targets.length;
 			while (--i > -1) {


### PR DESCRIPTION
There seem to be two issues with CSSPlugin.cascadeTo:
- The tween rendering doesn't set the "force" parameter when calculating CSS differences
- Calling .to instead of .fromTo causes the Tween to complete immediately when the parent's classname has been changed (which will be immediately of there are no CSS changes on the parent).

Demo of not working in base: http://jsfiddle.net/07jL7vfc/3/
Demo of fix: http://jsfiddle.net/z3u02utg/

