### PR TITLE
Fix bower install warnings.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "gsap",
     "version": "1.18.5",
-    "description": "Think of GSAP as the Swiss Army Knife of animation...but better. It animates anything JavaScript can touch (CSS properties, canvas library objects, SVG, generic objects, whatever) and it solves countless browser inconsistencies, all with blazing speed (up to 20x faster than jQuery), including automatic GPU-acceleration of transforms. See http://greensock.com/why-gsap/ for details. Most other libraries only animate CSS properties. Plus, their sequencing abilities and runtime controls pale by comparison. Simply put, GSAP is the most flexible high-performance animation library on the planet, which is probably why Google recommends it for JS-based animations and every major ad network excludes it from file size calculations. Unlike monolithic frameworks that dictate how you structure your apps, GSAP simply affects the animation layer; sprinkle it wherever you want. See http://greensock.com/gsap/ for details.",
+    "description": "The Swiss Army Knife of animation...but better.",
     "author": {
         "name": "Jack Doyle",
         "url": "http://greensock.com/gsap/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gsap",
     "filename": "TweenMax.min.js",
     "version": "1.18.5",
-    "description": "Think of GSAP as the Swiss Army Knife of animation...but better. It animates anything JavaScript can touch (CSS properties, canvas library objects, SVG, generic objects, whatever) and it solves countless browser inconsistencies, all with blazing speed (up to 20x faster than jQuery), including automatic GPU-acceleration of transforms. See http://greensock.com/why-gsap/ for details. Most other libraries only animate CSS properties. Plus, their sequencing abilities and runtime controls pale by comparison. Simply put, GSAP is the most flexible high-performance animation library on the planet, which is probably why Google recommends it for JS-based animations and every major ad network excludes it from file size calculations. Unlike monolithic frameworks that dictate how you structure your apps, GSAP simply affects the animation layer; sprinkle it wherever you want. See http://greensock.com/gsap/ for details.",
+    "description": "The  Swiss Army Knife of animation...but better.",
     "homepage": "http://greensock.com/gsap/",
 	"main": "./src/uncompressed/TweenMax.js",
     "keywords": [


### PR DESCRIPTION
Bower will emit a warning if the description in `bower.json` is over 140 characters. This PR changes the description in this project so that the warning is not emitted when installing this package.