### PR TITLE
Remove window from window.console calls

### DIFF
--- a/src/uncompressed/TweenMax.js
+++ b/src/uncompressed/TweenMax.js
@@ -7790,7 +7790,7 @@ if (_gsScope._gsDefine) { _gsScope._gsQueue.pop()(); } //necessary in case Tween
 			}
 			for (p in _defLookup) {
 				if (!_defLookup[p].func) {
-					window.console.log("GSAP encountered missing dependency: " + p);
+					console.log("GSAP encountered missing dependency: " + p);
 				}
 			}
 		}

--- a/src/uncompressed/jquery.gsap.js
+++ b/src/uncompressed/jquery.gsap.js
@@ -56,7 +56,7 @@
 			if (!TweenLite || !CSSPlugin || stale) {
 				TweenLite = null;
 				if (!_warned && window.console) {
-					window.console.log("The jquery.gsap.js plugin requires the TweenMax (or at least TweenLite and CSSPlugin) JavaScript file(s)." + (stale ? " Version " + version.join(".") + " is too old." : ""));
+					console.log("The jquery.gsap.js plugin requires the TweenMax (or at least TweenLite and CSSPlugin) JavaScript file(s)." + (stale ? " Version " + version.join(".") + " is too old." : ""));
 					_warned = true;
 				}
 				return;


### PR DESCRIPTION
`window` isn't needed in this case. I saw you weren't using it in CSSPlugin already: https://github.com/greensock/GreenSock-JS/blob/94c5d3100f78656c3a336ff1080ce22fba63394d/src/uncompressed/plugins/CSSPlugin.js#L99

```js

_log = function(s) {//for logging messages, but in a way that won't throw errors in old versions of IE.
	if (window.console) {
		console.log(s);
	}
}
```