### PR TITLE
Remove need for custom webpack configuration

### DIFF
--- a/src/uncompressed/TimelineLite.js
+++ b/src/uncompressed/TimelineLite.js
@@ -773,7 +773,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["./TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("./TweenLite.js"); //dependency
 		module.exports = getGlobal();

--- a/src/uncompressed/TimelineMax.js
+++ b/src/uncompressed/TimelineMax.js
@@ -1278,7 +1278,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["./TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("./TweenLite.js"); //dependency
 		module.exports = getGlobal();

--- a/src/uncompressed/easing/EasePack.js
+++ b/src/uncompressed/easing/EasePack.js
@@ -351,7 +351,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope);
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["../TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		module.exports = getGlobal();

--- a/src/uncompressed/plugins/BezierPlugin.js
+++ b/src/uncompressed/plugins/BezierPlugin.js
@@ -612,7 +612,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["../TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		module.exports = getGlobal();

--- a/src/uncompressed/plugins/CSSPlugin.js
+++ b/src/uncompressed/plugins/CSSPlugin.js
@@ -2818,7 +2818,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["../TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		module.exports = getGlobal();

--- a/src/uncompressed/plugins/CSSRulePlugin.js
+++ b/src/uncompressed/plugins/CSSRulePlugin.js
@@ -111,7 +111,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["../TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		module.exports = getGlobal();

--- a/src/uncompressed/plugins/ScrollToPlugin.js
+++ b/src/uncompressed/plugins/ScrollToPlugin.js
@@ -178,7 +178,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite"], getGlobal);
+		define(["../TweenLite"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		module.exports = getGlobal();

--- a/src/uncompressed/utils/Draggable.js
+++ b/src/uncompressed/utils/Draggable.js
@@ -2295,7 +2295,7 @@ var _gsScope = (typeof(module) !== "undefined" && module.exports && typeof(globa
 		return (_gsScope.GreenSockGlobals || _gsScope)[name];
 	};
 	if (typeof(define) === "function" && define.amd) { //AMD
-		define(["TweenLite", "CSSPlugin"], getGlobal);
+		define(["../TweenLite", "../CSSPlugin"], getGlobal);
 	} else if (typeof(module) !== "undefined" && module.exports) { //node
 		require("../TweenLite.js");
 		require("../plugins/CSSPlugin.js");


### PR DESCRIPTION
Fixes #186 

This seems to work in webpack. Those paths are read the same way as `require()` paths by webpack so they should be the same.

This fix shouldn't break existing webpack configurations, since what it does is _skip the user-defined aliases,_ which pointed to the same files anyway.

The only question mark is about real AMD environments like require.js.
 
Does anyone still use those with npm? How do they behave with relative paths? Do they work this with patch?