### PR TITLE
Fix node process hanging because of setTimeout (isomorphic app)

### DIFF
--- a/src/uncompressed/TweenLite.js
+++ b/src/uncompressed/TweenLite.js
@@ -443,7 +443,11 @@
 				if (_tickerActive && _getTime() - _lastUpdate > 2000) {
 					_ticker.wake();
 				}
-				setTimeout(_checkTimeout, 2000);
+				var timeout = setTimeout(_checkTimeout, 2000);
+				if (timeout.unref) {
+					// `unref` allows a node process to exit even if the timeout’s callback hasn’t been invoked. Without it, the node process is hanging as this function is called every two seconds.
+					timeout.unref();
+				}
 			};
 		_checkTimeout();
 

--- a/src/uncompressed/TweenMax.js
+++ b/src/uncompressed/TweenMax.js
@@ -6378,7 +6378,11 @@ if (_gsScope._gsDefine) { _gsScope._gsQueue.pop()(); } //necessary in case Tween
 				if (_tickerActive && _getTime() - _lastUpdate > 2000) {
 					_ticker.wake();
 				}
-				setTimeout(_checkTimeout, 2000);
+				var timeout = setTimeout(_checkTimeout, 2000);
+				if (timeout.unref) {
+					// `unref` allows a node process to exit even if the timeout’s callback hasn’t been invoked. Without it, the node process is hanging as this function is called every two seconds.
+					timeout.unref();
+				}
 			};
 		_checkTimeout();
 


### PR DESCRIPTION
Hi, my issue is explained there: https://github.com/gatsbyjs/gatsby/issues/953.
An easy way to reproduce this is to run `node TweenLite.js`. The process never exits, only because of this timeout.
This PR should fix this issue.
See: https://nodejs.org/api/timers.html#timers_timeout_unref for `.unref` doc.