### PR TITLE
Update TEMPLATE_Plugin.js

### DIFF
--- a/src/esm/TEMPLATE_Plugin.js
+++ b/src/esm/TEMPLATE_Plugin.js
@@ -71,4 +71,4 @@ export const YourPlugin = _gsScope._gsDefine.plugin({
 	});
 
 // Now export it for ES6
-export { YourPlugin, YourPlugin as default };
+export { YourPlugin as default };


### PR DESCRIPTION
Because YourPlugin has already been exported.So we can only export it as default.
I know that the module is  just a template.it should not be used directly.
but some static check system check it even i don't use it.
just a suggest.
thanks.